### PR TITLE
feat: handle deleting exercises sets and sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A Next.js and Convex-powered application to help track gym sets and manage progr
   - [x] Continue active workout (don't create new)
   - [x] Add exercises sets to workout
   - [x] Refactor exercise to have a equipment field (cable, machine, barbell, kettlebell, barbell etc.)
+  - [ ] Add custom exercises
   - [ ] Record sets with weight, reps, RPE
   - [ ] Workout history view
   - [ ] Workout completion flow with summary and notes

--- a/convex/exerciseSets.ts
+++ b/convex/exerciseSets.ts
@@ -112,6 +112,9 @@ export const addSet = mutation({
     if (!Number.isFinite(args.set.reps) || args.set.reps < 1) {
       throw new Error("Reps must be at least 1");
     }
+    if (args.set.notes && args.set.notes.length > 255) {
+      throw new Error("Notes must be no more than 255 characters");
+    }
 
     const set: Doc<"exerciseSets">["sets"][number] = {
       id: crypto.randomUUID(),

--- a/convex/exerciseSets.ts
+++ b/convex/exerciseSets.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
-import { Doc } from "./_generated/dataModel";
-import { mutation, query } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
+import { mutation, MutationCtx, query } from "./_generated/server";
 import { getCurrentUserOrThrow } from "./users";
 
 export const create = mutation({
@@ -16,6 +16,7 @@ export const create = mutation({
         "You are not allowed to add exercise sets to this workout session"
       );
     }
+
     const exercise = await ctx.db.get(args.exerciseId);
     if (!exercise) {
       throw new Error("Exercise not found");
@@ -102,15 +103,8 @@ export const addSet = mutation({
     }),
   },
   handler: async (ctx, args) => {
-    const user = await getCurrentUserOrThrow(ctx);
-    const exerciseSet = await ctx.db.get(args.exerciseSetId);
-    if (!exerciseSet) {
-      throw new Error("Exercise set not found");
-    }
-    const workoutSession = await ctx.db.get(exerciseSet.workoutSessionId);
-    if (!workoutSession || workoutSession.userId !== user._id) {
-      throw new Error("You are not allowed to modify this exercise set");
-    }
+    const { exerciseSet } = await assertAccess(ctx, args.exerciseSetId);
+
     // Basic validation
     if (!Number.isFinite(args.set.weight) || args.set.weight < 0) {
       throw new Error("Weight must be a non-negative number");
@@ -120,6 +114,7 @@ export const addSet = mutation({
     }
 
     const set: Doc<"exerciseSets">["sets"][number] = {
+      id: crypto.randomUUID(),
       weight: args.set.weight,
       reps: args.set.reps,
       notes: args.set.notes,
@@ -132,3 +127,48 @@ export const addSet = mutation({
     });
   },
 });
+
+export const deleteExerciseSet = mutation({
+  args: {
+    exerciseSetId: v.id("exerciseSets"),
+  },
+  handler: async (ctx, args) => {
+    await assertAccess(ctx, args.exerciseSetId);
+
+    await ctx.db.delete(args.exerciseSetId);
+  },
+});
+
+export const deleteSet = mutation({
+  args: {
+    exerciseSetId: v.id("exerciseSets"),
+    setId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { exerciseSet } = await assertAccess(ctx, args.exerciseSetId);
+
+    await ctx.db.patch(args.exerciseSetId, {
+      sets: exerciseSet.sets.filter((set) => set.id !== args.setId),
+    });
+  },
+});
+
+async function assertAccess(
+  ctx: MutationCtx,
+  exerciseSetId: Id<"exerciseSets">
+) {
+  const user = await getCurrentUserOrThrow(ctx);
+  const exerciseSet = await ctx.db.get(exerciseSetId);
+  if (!exerciseSet) {
+    throw new Error("Exercise set not found");
+  }
+  const workoutSession = await ctx.db.get(exerciseSet.workoutSessionId);
+  if (!workoutSession || workoutSession.userId !== user._id) {
+    throw new Error("You are not authorised to edit this data");
+  }
+
+  return {
+    exerciseSet,
+    workoutSession,
+  };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -95,6 +95,7 @@ export default defineSchema({
     isActive: v.boolean(),
     sets: v.array(
       v.object({
+        id: v.string(),
         reps: v.number(),
         weight: v.number(),
         weightUnit: v.union(v.literal("lbs"), v.literal("kg")),

--- a/src/components/ui/delete-dialog.tsx
+++ b/src/components/ui/delete-dialog.tsx
@@ -1,0 +1,66 @@
+import { Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog";
+import { Button } from "./button";
+
+interface DeleteDialogProps {
+  disabled?: boolean;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmButtonText: string;
+  triggerTitle?: string;
+  triggerSize?: "sm" | "default" | "lg";
+  triggerVariant?: "ghost" | "outline" | "destructive";
+  children?: React.ReactNode;
+}
+
+export function DeleteDialog({
+  disabled = false,
+  onConfirm,
+  title,
+  description,
+  confirmButtonText,
+  triggerTitle = "Delete",
+  children,
+}: DeleteDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        {children || (
+          <Button
+            variant="ghost"
+            size="sm"
+            title={triggerTitle}
+            disabled={disabled}
+          >
+            <Trash2 className="h-4 w-4 text-destructive" />
+          </Button>
+        )}
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button variant="destructive" asChild>
+            <AlertDialogAction onClick={onConfirm}>
+              {confirmButtonText}
+            </AlertDialogAction>
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/workout-drawer/exercise-set-form.tsx
+++ b/src/components/workout-drawer/exercise-set-form.tsx
@@ -1,10 +1,22 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery } from "convex/react";
+import { Trash2 } from "lucide-react";
 import { useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "../ui/alert-dialog";
 import { Button } from "../ui/button";
 import {
   Form,
@@ -53,6 +65,8 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
   });
   const addSetMutation = useMutation(api.exerciseSets.addSet);
   const setActiveMutation = useMutation(api.exerciseSets.setActive);
+  const deleteSetMutation = useMutation(api.exerciseSets.deleteSet);
+
   const [isPending, startTransition] = useTransition();
 
   const form = useForm<ExerciseSetFormData>({
@@ -98,6 +112,15 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
     });
   }
 
+  const handleDeleteSet = async (setId: string) => {
+    startTransition(async () => {
+      await deleteSetMutation({
+        exerciseSetId,
+        setId,
+      });
+    });
+  };
+
   return (
     <div className="space-y-3">
       {exerciseSet ? (
@@ -108,6 +131,7 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
                 <TableHead className="w-16">Set</TableHead>
                 <TableHead>Weight</TableHead>
                 <TableHead>Reps</TableHead>
+                <TableHead className="w-16">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -119,6 +143,12 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
                     {set.weightUnit}
                   </TableCell>
                   <TableCell>{set.reps}</TableCell>
+                  <TableCell className="text-right">
+                    <DeleteSetAlert
+                      disabled={isPending}
+                      onConfirm={() => handleDeleteSet(set.id)}
+                    />
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -235,5 +265,45 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
         </Form>
       ) : null}
     </div>
+  );
+}
+
+function DeleteSetAlert({
+  disabled,
+  onConfirm,
+}: {
+  disabled: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          title="Delete set"
+          disabled={disabled}
+        >
+          <Trash2 className="h-4 w-4 text-destructive" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Set</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete this set? This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button variant="destructive" asChild>
+            <AlertDialogAction onClick={onConfirm}>
+              Delete Set
+            </AlertDialogAction>
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/src/components/workout-drawer/exercise-set-form.tsx
+++ b/src/components/workout-drawer/exercise-set-form.tsx
@@ -1,23 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery } from "convex/react";
-import { Trash2 } from "lucide-react";
 import { useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "../ui/alert-dialog";
 import { Button } from "../ui/button";
+import { DeleteDialog } from "../ui/delete-dialog";
 import {
   Form,
   FormControl,
@@ -144,9 +133,13 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
                   </TableCell>
                   <TableCell>{set.reps}</TableCell>
                   <TableCell className="text-right">
-                    <DeleteSetAlert
+                    <DeleteDialog
                       disabled={isPending}
                       onConfirm={() => handleDeleteSet(set.id)}
+                      title="Delete Set"
+                      description="Are you sure you want to delete this set? This action cannot be undone."
+                      confirmButtonText="Delete Set"
+                      triggerTitle="Delete set"
                     />
                   </TableCell>
                 </TableRow>
@@ -265,45 +258,5 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
         </Form>
       ) : null}
     </div>
-  );
-}
-
-function DeleteSetAlert({
-  disabled,
-  onConfirm,
-}: {
-  disabled: boolean;
-  onConfirm: () => void;
-}) {
-  return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          title="Delete set"
-          disabled={disabled}
-        >
-          <Trash2 className="h-4 w-4 text-destructive" />
-        </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete Set</AlertDialogTitle>
-          <AlertDialogDescription>
-            Are you sure you want to delete this set? This action cannot be
-            undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <Button variant="destructive" asChild>
-            <AlertDialogAction onClick={onConfirm}>
-              Delete Set
-            </AlertDialogAction>
-          </Button>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
   );
 }

--- a/src/components/workout-drawer/workout-drawer.tsx
+++ b/src/components/workout-drawer/workout-drawer.tsx
@@ -1,21 +1,11 @@
 import { cn } from "@/lib/utils";
 import { useMutation, useQuery } from "convex/react";
-import { Edit, Plus, PlusCircle, Save, Trash2 } from "lucide-react";
+import { Edit, Plus, PlusCircle, Save } from "lucide-react";
 import { useEffect, useState, useTransition } from "react";
 import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "../ui/alert-dialog";
 import { Button } from "../ui/button";
+import { DeleteDialog } from "../ui/delete-dialog";
 import {
   Drawer,
   DrawerContent,
@@ -37,7 +27,6 @@ export function WorkoutDrawer() {
   const [open, setOpen] = useState(false);
   const [workoutSessionId, setWorkoutSessionId] =
     useState<Id<"workoutSessions"> | null>(null);
-  const [deleteAlertOpen, setDeleteAlertOpen] = useState(false);
 
   const createWorkoutSession = useMutation(api.workoutSessions.getOrCreate);
   const deleteWorkoutSession = useMutation(
@@ -46,9 +35,6 @@ export function WorkoutDrawer() {
   const completeMutation = useMutation(api.workoutSessions.complete);
   const createExerciseSet = useMutation(api.exerciseSets.create);
   const deleteExerciseSet = useMutation(api.exerciseSets.deleteExerciseSet);
-
-  // TODO: Add mutation for deleting exercise sets
-  // const deleteExerciseSetMutation = useMutation(api.exerciseSets.deleteExerciseSet);
 
   const exerciseSets = useQuery(
     api.exerciseSets.getSets,
@@ -83,7 +69,6 @@ export function WorkoutDrawer() {
     startTransition(async () => {
       await deleteWorkoutSession({ id: workoutSessionId });
       setOpen(false);
-      setDeleteAlertOpen(false);
       setWorkoutSessionId(null);
     });
   };
@@ -137,11 +122,15 @@ export function WorkoutDrawer() {
                         {exerciseSet.exercise?.name}
                       </p>
                       {exerciseSet.isActive ? (
-                        <DeleteExerciseAlert
+                        <DeleteDialog
                           disabled={isPending}
                           onConfirm={() =>
                             handleDeleteExercise(exerciseSet._id)
                           }
+                          title="Delete Exercise"
+                          description="Are you sure you want to delete this exercise? All sets will be permanently removed. This action cannot be undone."
+                          confirmButtonText="Delete Exercise"
+                          triggerTitle="Delete exercise"
                         />
                       ) : (
                         <button title="Start exercise">
@@ -175,31 +164,14 @@ export function WorkoutDrawer() {
             />
 
             <DrawerFooter className="flex flex-row gap-2 max-w-xl mx-auto w-full">
-              <AlertDialog
-                open={deleteAlertOpen}
-                onOpenChange={setDeleteAlertOpen}
+              <DeleteDialog
+                onConfirm={handleDeleteWorkout}
+                title="Delete Workout"
+                description="Are you sure you want to delete this workout? This action cannot be undone."
+                confirmButtonText="Delete"
               >
-                <AlertDialogTrigger asChild>
-                  <Button variant="outline">Delete Workout</Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Delete Workout</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Are you sure you want to delete this workout? This action
-                      cannot be undone.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <Button variant="destructive" asChild>
-                      <AlertDialogAction onClick={handleDeleteWorkout}>
-                        Delete
-                      </AlertDialogAction>
-                    </Button>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+                <Button variant="outline">Delete Workout</Button>
+              </DeleteDialog>
 
               <Button
                 className="grow"
@@ -227,45 +199,5 @@ export function WorkoutDrawer() {
         </DrawerContent>
       </Drawer>
     </>
-  );
-}
-
-export function DeleteExerciseAlert({
-  disabled,
-  onConfirm,
-}: {
-  disabled: boolean;
-  onConfirm: () => void;
-}) {
-  return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          title="Delete exercise"
-          disabled={disabled}
-        >
-          <Trash2 className="h-4 w-4 text-destructive" />
-        </Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete Exercise</AlertDialogTitle>
-          <AlertDialogDescription>
-            Are you sure you want to delete this exercise? All sets will be
-            permanently removed. This action cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <Button variant="destructive" asChild>
-            <AlertDialogAction onClick={onConfirm}>
-              Delete Exercise
-            </AlertDialogAction>
-          </Button>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Delete individual sets from an exercise with a confirmation dialog.
  - Delete entire exercise sets with a confirmation dialog.
  - Sets now carry unique IDs, enabling precise per-set actions.
  - New set entries include weight unit and bodyweight flags.

- Changes
  - Stopped auto-deleting empty workout sessions when the drawer unmounts, preserving user data unless explicitly removed.

- UI
  - Added trash actions and confirmation alerts in set tables and exercise lists.
  - Actions are disabled during pending operations for smoother, safer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->