### PR TITLE
feat: add body weight option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Next.js and Convex-powered application to help track gym sets and manage progr
 - [ ] No way to sign out
 - [ ] Toast descriptions are too light for example when used for push notification toasts
 - [ ] Notifications section in settings. Green tick is squashed on Iphone
+- [ ] The PB styling on sets when it comes to body weight is not working as intended
 
 ### Phase 1: Project Setup & Dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A Next.js and Convex-powered application to help track gym sets and manage progr
 
 ## 🏋️‍♂️ Development Todo List
 
-// TODO: add an is body weight option to UI
-
 ### Bugs
 
 - [x] Remove cardio exercises from the exercise library

--- a/convex/exerciseSets.ts
+++ b/convex/exerciseSets.ts
@@ -111,9 +111,11 @@ export const addSet = mutation({
       args.exerciseSetId
     );
 
-    // Basic validation
-    if (!Number.isFinite(args.set.weight) || args.set.weight < 0) {
-      throw new Error("Weight must be a non-negative number");
+    // Basic validation (only for non‑BW sets; BW uses user.bodyWeight)
+    if (!args.isBodyWeight) {
+      if (!Number.isFinite(args.set.weight) || args.set.weight <= 0) {
+        throw new Error("Weight must be a positive number");
+      }
     }
     if (!Number.isFinite(args.set.reps) || args.set.reps < 1) {
       throw new Error("Reps must be at least 1");
@@ -122,8 +124,14 @@ export const addSet = mutation({
       throw new Error("Notes must be no more than 255 characters");
     }
 
-    if (args.isBodyWeight && !user.bodyWeight === undefined) {
-      throw new Error("Body weight is not set");
+    if (args.isBodyWeight) {
+      if (
+        user.bodyWeight === undefined ||
+        !Number.isFinite(user.bodyWeight) ||
+        user.bodyWeight <= 0
+      ) {
+        throw new Error("Body weight must be set and positive");
+      }
     }
 
     const weightUnit = args.isBodyWeight
@@ -135,8 +143,8 @@ export const addSet = mutation({
       throw new Error("Weight unit is not set");
     }
 
-    if (!weight) {
-      throw new Error("Weight is not set");
+    if (!Number.isFinite(weight) || weight === undefined || weight <= 0) {
+      throw new Error("Weight must be a positive number");
     }
 
     const set: Doc<"exerciseSets">["sets"][number] = {

--- a/convex/lib/exercise_performance.ts
+++ b/convex/lib/exercise_performance.ts
@@ -40,10 +40,9 @@ export async function updatePersonalBest(
     return;
   }
 
-  const bestSet = getBestSet(allSets);
+  const bestSet = getBestSet(allSets) as (typeof allSets)[number];
 
   // Resolve workout date from the session that contains the PB set
-  if (!bestSet._sessionId) return;
   const bestSession = await ctx.db.get(bestSet._sessionId);
   if (!bestSession) return;
   const workoutDate = bestSession.startedAt;

--- a/convex/lib/exercise_performance.ts
+++ b/convex/lib/exercise_performance.ts
@@ -1,4 +1,4 @@
-import { Id } from "../_generated/dataModel";
+import { Doc, Id } from "../_generated/dataModel";
 import { MutationCtx } from "../_generated/server";
 
 export async function updatePersonalBest(
@@ -30,6 +30,7 @@ export async function updatePersonalBest(
         q.eq("userId", userId).eq("exerciseId", exerciseId)
       )
       .first();
+
     if (existingPerformance) {
       await ctx.db.patch(existingPerformance._id, {
         personalBest: undefined,
@@ -39,15 +40,10 @@ export async function updatePersonalBest(
     return;
   }
 
-  // Find the best set (highest weight, then highest reps if weights are equal)
-  const bestSet = allSets.reduce((best, current) => {
-    if (current.weight > best.weight) return current;
-    if (current.weight === best.weight && current.reps > best.reps)
-      return current;
-    return best;
-  });
+  const bestSet = getBestSet(allSets);
 
   // Resolve workout date from the session that contains the PB set
+  if (!bestSet._sessionId) return;
   const bestSession = await ctx.db.get(bestSet._sessionId);
   if (!bestSession) return;
   const workoutDate = bestSession.startedAt;
@@ -67,9 +63,13 @@ export async function updatePersonalBest(
   const existingBestReps = personalBest?.reps ?? 0;
 
   // Update personal best if weight is higher, or if weight is equal and reps are higher
-  const isNewPersonalBest =
+  let isNewPersonalBest =
     bestWeight > existingBestWeight ||
     (bestWeight === existingBestWeight && bestReps > existingBestReps);
+
+  if (bestSet.isBodyWeight) {
+    isNewPersonalBest = bestReps > existingBestReps;
+  }
 
   if (isNewPersonalBest) {
     personalBest = {
@@ -106,10 +106,9 @@ export async function updateLastWorkoutData(
   // Get all exercise sets for this exercise in this workout session
   const exerciseSets = await ctx.db
     .query("exerciseSets")
-    .withIndex("by_workout_session_id", (q) =>
-      q.eq("workoutSessionId", workoutSessionId)
+    .withIndex("by_workout_session_id_and_exercise_id", (q) =>
+      q.eq("workoutSessionId", workoutSessionId).eq("exerciseId", exerciseId)
     )
-    .filter((q) => q.eq(q.field("exerciseId"), exerciseId))
     .collect();
 
   // Calculate performance metrics from all sets
@@ -121,14 +120,7 @@ export async function updateLastWorkoutData(
   if (!workoutSession) return;
 
   const workoutDate = workoutSession.startedAt;
-
-  // Find the best set (highest weight, then highest reps if weights are equal)
-  const bestSet = allSets.reduce((best, current) => {
-    if (current.weight > best.weight) return current;
-    if (current.weight === best.weight && current.reps > best.reps)
-      return current;
-    return best;
-  });
+  const bestSet = getBestSet(allSets);
 
   // Get existing performance record
   const existingPerformance = await ctx.db
@@ -169,4 +161,26 @@ export async function updateLastWorkoutData(
   }
 
   await ctx.db.insert("exercisePerformance", performanceData);
+}
+
+function getBestSet(
+  sets: (Doc<"exerciseSets">["sets"][number] & {
+    _sessionId?: Id<"workoutSessions">;
+  })[]
+) {
+  // Find the best set (highest weight, then highest reps if weights are equal unless
+  // it's a body weight set - accounts for reps only)
+  const bestSet = sets.reduce((best, current) => {
+    if (current.isBodyWeight) {
+      if (current.reps > best.reps) return current;
+      if (current.reps === best.reps && current.weight > best.weight)
+        return current;
+      return best;
+    }
+    if (current.weight > best.weight) return current;
+    if (current.weight === best.weight && current.reps > best.reps)
+      return current;
+    return best;
+  });
+  return bestSet;
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -114,6 +114,7 @@ export default defineSchema({
     exerciseId: v.id("exercises"),
     lastWeight: v.optional(v.number()),
     lastWeightUnit: v.optional(v.union(v.literal("lbs"), v.literal("kg"))),
+    lastIsBodyWeight: v.optional(v.boolean()),
     lastReps: v.optional(v.number()),
     lastSets: v.optional(v.number()),
     lastWorkoutDate: v.optional(v.number()),
@@ -121,6 +122,7 @@ export default defineSchema({
       v.object({
         weight: v.number(),
         weightUnit: v.union(v.literal("lbs"), v.literal("kg")),
+        isBodyWeight: v.boolean(),
         reps: v.number(),
         date: v.number(),
       })

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -103,6 +103,10 @@ export default defineSchema({
     ),
   })
     .index("by_workout_session_id", ["workoutSessionId"])
+    .index("by_workout_session_id_and_exercise_id", [
+      "workoutSessionId",
+      "exerciseId",
+    ])
     .index("by_exercise_id_and_user_id", ["exerciseId", "userId"]),
 
   exercisePerformance: defineTable({

--- a/src/components/workout-drawer/exercise-set-form.tsx
+++ b/src/components/workout-drawer/exercise-set-form.tsx
@@ -120,7 +120,7 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
         const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
         if (user.lastBodyWeightUpdate < sevenDaysAgo) {
           toast.warning(
-            "Your body weight hasn't been updated in over 7 days. Please update it in settings for accurate tracking."
+            "Your body weight hasn't been updated in over 7 days. Consider updating it in settings for accuracy."
           );
           return;
         }
@@ -237,9 +237,13 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
               <p className="flex items-center gap-2">
                 <span className="font-medium text-muted-foreground">PB:</span>
                 <span className="font-semibold">
-                  {exercisePerformance.personalBest?.weight}
-                  {exercisePerformance.personalBest?.weightUnit ||
-                    ""} &times; {exercisePerformance.personalBest?.reps}
+                  {exercisePerformance.personalBest?.isBodyWeight
+                    ? "BW"
+                    : exercisePerformance.personalBest?.weight}
+                  {exercisePerformance.personalBest?.isBodyWeight
+                    ? ""
+                    : exercisePerformance.personalBest?.weightUnit || ""}{" "}
+                  &times; {exercisePerformance.personalBest?.reps}
                 </span>
               </p>
               {exercisePerformance.lastWeight ? (
@@ -248,9 +252,13 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
                     Last Time:
                   </span>
                   <span className="font-semibold">
-                    {exercisePerformance.lastWeight}
-                    {exercisePerformance.lastWeightUnit || ""} &times;{" "}
-                    {exercisePerformance.lastReps}
+                    {exercisePerformance.lastIsBodyWeight
+                      ? "BW"
+                      : exercisePerformance.lastWeight}
+                    {exercisePerformance.lastIsBodyWeight
+                      ? ""
+                      : exercisePerformance.lastWeightUnit || ""}{" "}
+                    &times; {exercisePerformance.lastReps}
                   </span>{" "}
                   {exercisePerformance.lastSets ? (
                     <span className="font-semibold">
@@ -364,7 +372,7 @@ export function ExerciseSetForm({ exerciseSetId }: ExerciseSetFormProps) {
                           </span>
                         ) : null}
                         <Input
-                          min={0}
+                          min={isBodyWeight ? undefined : 1}
                           placeholder={isBodyWeight ? "Body Weight" : "0"}
                           type="number"
                           inputMode="numeric"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add body‑weight mode for exercise sets: toggle to use your saved body weight and unit, with “BW” shown in set lists and PBs.
- **UX Improvements**
  - Weight input auto‑disables and clears when body‑weight mode is on; header shows current body weight.
  - Validations and warnings for missing/invalid body weight and if it’s older than 7 days.
  - Personal best and match indicators now respect body‑weight semantics.
- **Documentation**
  - Added a TODO noting a PB styling issue for body‑weight sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->